### PR TITLE
Fix minor errors when using Arduino single bitmap

### DIFF
--- a/js/script.js
+++ b/js/script.js
@@ -948,7 +948,7 @@ function generateOutputString() {
       images.each((image) => {
         code = imageToString(image);
         code = `\t${code.split('\n').join('\n\t')}\n`;
-        comment = `\t// '${image.glyph}, ${image.canvas.width}x${image.canvas.height}px\n`;
+        comment = `\t// '${image.glyph}', ${image.canvas.width}x${image.canvas.height}px\n`;
         outputString += comment + code;
         if (image.glyph.length === 1) {
           useGlyphs++;

--- a/js/script.js
+++ b/js/script.js
@@ -936,7 +936,7 @@ function generateOutputString() {
       outputString = outputString.replace(/,\s*$/, '');
 
       outputString = `const ${getImageType()} ${
-        +getIdentifier()
+        getIdentifier()
       } [] PROGMEM = {`
             + `\n${outputString}\n};`;
       break;

--- a/js/script.js
+++ b/js/script.js
@@ -1060,6 +1060,7 @@ function updateDrawMode(elm) {
   if (conversionFunction) {
     settings.conversionFunction = conversionFunction;
   }
+  updateAllImages();
 }
 
 // Updates Arduino code check-box


### PR DESCRIPTION
Fixes the array name showing wrong and comment labels missing a closing quote when using Arduino single bitmap mode.

Also had updateDrawMode update the preview, so if you pick a colored draw mode it reflects that immediately.